### PR TITLE
Fixing plat_specific_sv_name logic to work with Amazon Linux 2

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -60,7 +60,7 @@ plat_specific_sv_name = case node['platform_family']
                           else
                             'runit'
                           end
-                        when 'rhel'
+                        when 'rhel', 'amazon'
                           if node['platform_version'].to_i >= 7 && !platform?('amazon')
                             'runsvdir-start'
                           elsif node['platform_version'].to_i == 2 && platform?('amazon')


### PR DESCRIPTION
node['platform_family'] for amazon linux 2 now returns 'amazon' not 'rhel'.
This needs to be updated as the service name is now 'runsvdir-start' but its trying to use the default 'runsvdir'
- [X] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [X] New functionality includes testing.
- [X] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
